### PR TITLE
Rework boundary conditions to avoid duplicating code

### DIFF
--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -126,7 +126,7 @@ def artificial_viscosity(discr, t, eos, boundaries, r, alpha):
             )
             return _facial_flux_r(discr, q_tpair=q_tpair)
 
-        r_ext = boundaries[btag].exterior_sol(discr, eos=eos, btag=btag, t=t, q=r)
+        r_ext = boundaries[btag].exterior_soln(discr, eos=eos, btag=btag, t=t, q=r)
         r_int = discr.project("vol", btag, r)
         dbf_r = dbf_r + obj_array_vectorize_n_args(
             my_facialflux_r_boundary, r_ext, r_int

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -35,7 +35,6 @@ THE SOFTWARE.
 import numpy as np
 from meshmode.dof_array import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from mirgecom.eos import IdealSingleGas
 from mirgecom.euler import split_conserved, join_conserved
 from grudge.symbolic.primitives import TracePair
 
@@ -121,7 +120,6 @@ class AdiabaticSlipBoundary:
 
     def boundary_pair(self, discr, q, btag, **kwargs):
         """Get the interior and exterior solution on the boundary."""
-
         bndry_soln = self.exterior_soln(discr, q, btag, **kwargs)
         int_soln = discr.project("vol", btag, q)
 
@@ -167,7 +165,6 @@ class AdiabaticSlipBoundary:
 
     def av(self, discr, q, btag, **kwargs):
         """Get the exterior solution on the boundary."""
-
         # Grab some boundary-relevant data
         dim = discr.dim
         cv = split_conserved(dim, q)

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -61,7 +61,7 @@ class PrescribedBoundary:
 
     def boundary_pair(self, discr, q, btag, **kwargs):
         """Get the interior and exterior solution on the boundary."""
-        ext_soln = self.exterior_soln(self, discr, q, btag, **kwargs)
+        ext_soln = self.exterior_soln(discr, q, btag, **kwargs)
         int_soln = discr.project("vol", btag, q)
         return TracePair(btag, interior=int_soln, exterior=ext_soln)
 
@@ -87,7 +87,7 @@ class DummyBoundary:
 
     def boundary_pair(self, discr, q, btag, **kwargs):
         """Get the interior and exterior solution on the boundary."""
-        dir_soln = self.exterior_soln(self, discr, q, btag, **kwargs)
+        dir_soln = self.exterior_soln(discr, q, btag, **kwargs)
         return TracePair(btag, interior=dir_soln, exterior=dir_soln)
 
     def exterior_soln(self, discr, q, btag, **kwargs):

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -62,29 +62,21 @@ class PrescribedBoundary:
 
     def boundary_pair(self, discr, q, btag, **kwargs):
         """Get the interior and exterior solution on the boundary."""
+        ext_soln = self.exterior_soln(self, discr, q, btag, **kwargs)
+        int_soln = discr.project("vol", btag, q)
+        return TracePair(btag, interior=int_soln, exterior=ext_soln)
+
+    def exterior_soln(self, discr, q, btag, **kwargs):
+        """Get the exterior solution on the boundary."""
         actx = q[0].array_context
 
         boundary_discr = discr.discr_from_dd(btag)
         nodes = thaw(actx, boundary_discr.nodes())
         ext_soln = self._userfunc(nodes, **kwargs)
-        int_soln = discr.project("vol", btag, q)
-        return TracePair(btag, interior=int_soln, exterior=ext_soln)
-
-    def exterior_sol(
-            self, discr, q, t=0.0, btag=BTAG_ALL, eos=IdealSingleGas()
-    ):
-        """Get the interior solution on the boundary."""
-        actx = q[0].array_context
-
-        boundary_discr = discr.discr_from_dd(btag)
-        nodes = thaw(actx, boundary_discr.nodes())
-        ext_soln = self._userfunc(t, nodes)
         return ext_soln
 
-    def av(
-            self, discr, q, t=0.0, btag=BTAG_ALL, eos=IdealSingleGas()
-    ):
-        """Do artificial viscosity function."""
+    def av(self, discr, q, btag, **kwargs):
+        """Get the exterior solution on the boundary."""
         return discr.project("vol", btag, q)
 
 
@@ -96,20 +88,16 @@ class DummyBoundary:
 
     def boundary_pair(self, discr, q, btag, **kwargs):
         """Get the interior and exterior solution on the boundary."""
-        dir_soln = discr.project("vol", btag, q)
+        dir_soln = self.exterior_soln(self, discr, q, btag, **kwargs)
         return TracePair(btag, interior=dir_soln, exterior=dir_soln)
 
-    def exterior_sol(
-        self, discr, q, t=0.0, btag=BTAG_ALL, eos=IdealSingleGas()
-    ):
-        """Get the interior and exterior solution on the boundary."""
+    def exterior_soln(self, discr, q, btag, **kwargs):
+        """Get the exterior solution on the boundary."""
         dir_soln = discr.project("vol", btag, q)
         return dir_soln
 
-    def av(
-            self, discr, q, t=0.0, btag=BTAG_ALL, eos=IdealSingleGas()
-    ):
-        """Do artificial viscosity function."""
+    def av(self, discr, q, btag, **kwargs):
+        """Get the exterior solution on the boundary."""
         return discr.project("vol", btag, q)
 
 
@@ -132,48 +120,15 @@ class AdiabaticSlipBoundary:
     """
 
     def boundary_pair(self, discr, q, btag, **kwargs):
-        """Get the interior and exterior solution on the boundary.
+        """Get the interior and exterior solution on the boundary."""
 
-        The exterior solution is set such that there will be vanishing
-        flux through the boundary, preserving mass, momentum (magnitude) and
-        energy.
-        rho_plus = rho_minus
-        v_plus = v_minus - 2 * (v_minus . n_hat) * n_hat
-        mom_plus = rho_plus * v_plus
-        E_plus = E_minus
-        """
-        # Grab some boundary-relevant data
-        dim = discr.dim
-        cv = split_conserved(dim, q)
-        actx = cv.mass.array_context
-
-        # Grab a unit normal to the boundary
-        nhat = thaw(actx, discr.normal(btag))
-
-        # Get the interior/exterior solns
+        bndry_soln = self.exterior_soln(discr, q, btag, **kwargs)
         int_soln = discr.project("vol", btag, q)
-        int_cv = split_conserved(dim, int_soln)
-
-        # Subtract out the 2*wall-normal component
-        # of velocity from the velocity at the wall to
-        # induce an equal but opposite wall-normal (reflected) wave
-        # preserving the tangential component
-        mom_normcomp = np.dot(int_cv.momentum, nhat)  # wall-normal component
-        wnorm_mom = nhat * mom_normcomp  # wall-normal mom vec
-        ext_mom = int_cv.momentum - 2.0 * wnorm_mom  # prescribed ext momentum
-
-        # Form the external boundary solution with the new momentum
-        bndry_soln = join_conserved(dim=dim, mass=int_cv.mass,
-                                    energy=int_cv.energy,
-                                    momentum=ext_mom,
-                                    species_mass=int_cv.species_mass)
 
         return TracePair(btag, interior=int_soln, exterior=bndry_soln)
 
-    def exterior_sol(
-            self, discr, q, t=0.0, btag=BTAG_ALL, eos=IdealSingleGas()
-    ):
-        """Get the interior and exterior solution on the boundary.
+    def exterior_soln(self, discr, q, btag, **kwargs):
+        """Get the exterior solution on the boundary.
 
         The exterior solution is set such that there will be vanishing
         flux through the boundary, preserving mass, momentum (magnitude) and
@@ -210,10 +165,9 @@ class AdiabaticSlipBoundary:
 
         return bndry_soln
 
-    def av(
-            self, discr, q, t=0.0, btag=BTAG_ALL, eos=IdealSingleGas()
-    ):
-        """Do artificial viscosity function."""
+    def av(self, discr, q, btag, **kwargs):
+        """Get the exterior solution on the boundary."""
+
         # Grab some boundary-relevant data
         dim = discr.dim
         cv = split_conserved(dim, q)


### PR DESCRIPTION
The goal is to rework boundary conditions to avoid duplication of code. The artificial viscosity calculation requires access to the external solution directly and not the trace_pair. As such this moves the external solution calculation to a separate routine which is then called by boundary pair.